### PR TITLE
HashCodeHelper

### DIFF
--- a/Core/ALife.Core/Utility/Colours/Colour.cs
+++ b/Core/ALife.Core/Utility/Colours/Colour.cs
@@ -504,8 +504,7 @@ namespace ALife.Core.Utility.Colours
         /// </returns>
         public override int GetHashCode()
         {
-            int hash = A + B + G + R;
-            return hash.GetHashCode();
+            return HashCodeHelper.Combine(A, R, G, B);
         }
 
         /// <summary>

--- a/Core/ALife.Core/Utility/Colours/HslColour.cs
+++ b/Core/ALife.Core/Utility/Colours/HslColour.cs
@@ -552,8 +552,7 @@ namespace ALife.Core.Utility.Colours
         /// </returns>
         public override int GetHashCode()
         {
-            int hash = A + B + G + R;
-            return hash.GetHashCode();
+            return HashCodeHelper.Combine(A, R, G, B, Hue, Saturation, Lightness);
         }
 
         /// <summary>

--- a/Core/ALife.Core/Utility/Colours/HsvColour.cs
+++ b/Core/ALife.Core/Utility/Colours/HsvColour.cs
@@ -552,8 +552,7 @@ namespace ALife.Core.Utility.Colours
         /// </returns>
         public override int GetHashCode()
         {
-            int hash = A + B + G + R;
-            return hash.GetHashCode();
+            return HashCodeHelper.Combine(A, R, G, B, Hue, Saturation, Value);
         }
 
         /// <summary>

--- a/Core/ALife.Core/Utility/Colours/TslColour.cs
+++ b/Core/ALife.Core/Utility/Colours/TslColour.cs
@@ -552,8 +552,7 @@ namespace ALife.Core.Utility.Colours
         /// </returns>
         public override int GetHashCode()
         {
-            int hash = A + B + G + R;
-            return hash.GetHashCode();
+            return HashCodeHelper.Combine(A, R, G, B, Tint, Saturation, Lightness);
         }
 
         /// <summary>

--- a/Core/ALife.Core/Utility/EvoNumbers/EvoNumber.cs
+++ b/Core/ALife.Core/Utility/EvoNumbers/EvoNumber.cs
@@ -320,11 +320,9 @@ namespace ALife.Core.Utility.EvoNumbers
         /// <returns>
         /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table.
         /// </returns>
-        //TODO: This hashcode override might not be necessary
         public override int GetHashCode()
         {
-            int hashCode = Value.GetHashCode() ^ ValueDeltaMaximum.GetHashCode() ^ ValueMaximum.GetHashCode() ^ ValueMinimum.GetHashCode();
-            return hashCode;
+            return HashCodeHelper.Combine(Value, ValueDeltaMaximum, ValueMaximum, ValueMinimum, ValueMaximumAndMinimumEvolutionDeltaMax, OriginalValue, OriginalValueEvolutionDeltaMax);
         }
 
         /// <summary>

--- a/Core/ALife.Core/Utility/EvoNumbers/ReadOnlyEvoNumber.cs
+++ b/Core/ALife.Core/Utility/EvoNumbers/ReadOnlyEvoNumber.cs
@@ -334,8 +334,7 @@ namespace ALife.Core.Utility.EvoNumbers
         /// </returns>
         public override int GetHashCode()
         {
-            int hashCode = Value.GetHashCode() ^ ValueDeltaMaximum.GetHashCode() ^ ValueMaximum.GetHashCode() ^ ValueMinimum.GetHashCode();
-            return hashCode;
+            return HashCodeHelper.Combine(Value, ValueDeltaMaximum, ValueMaximum, ValueMinimum, ValueMaximumAndMinimumEvolutionDeltaMax, OriginalValue, OriginalValueEvolutionDeltaMax);
         }
 
         /// <summary>

--- a/Core/ALife.Core/Utility/HashCodeHelpers.cs
+++ b/Core/ALife.Core/Utility/HashCodeHelpers.cs
@@ -1,0 +1,36 @@
+﻿namespace ALife.Core.Utility
+{
+    /// <summary>
+    /// Various helpers for hashcodes.
+    /// </summary>
+    public static class HashCodeHelper
+    {
+        /// <summary>
+        /// Combines the hash codes into a single hash code.
+        /// </summary>
+        /// <param name="hashCodes">The hashcodes to combine.</param>
+        /// <returns>The combined hashcode.</returns>
+        public static int Combine(params int[] hashCodes)
+        {
+            string hashString = string.Join(",", hashCodes);
+            int hash = hashString.GetHashCode();
+            return hash;
+        }
+
+        /// <summary>
+        /// Combines the hash codes of the objects into a single hash code.
+        /// </summary>
+        /// <param name="objects"></param>
+        /// <returns>The combined hashcode.</returns>
+        public static int Combine(params object[] objects)
+        {
+            int[] hashes = new int[objects.Length];
+            for(int i = 0; i < objects.Length; i++)
+            {
+                hashes[i] = objects[i].GetHashCode();
+            }
+
+            return Combine(hashes);
+        }
+    }
+}

--- a/Core/ALife.Core/Utility/Numerics/BoundedNumber.cs
+++ b/Core/ALife.Core/Utility/Numerics/BoundedNumber.cs
@@ -188,11 +188,9 @@ namespace ALife.Core.Utility.Numerics
         /// <returns>
         /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table.
         /// </returns>
-        //TODO: Is there an integeroverflow risk here?
         public override int GetHashCode()
         {
-            int hashCode = _range.GetHashCode() + _value.GetHashCode();
-            return hashCode;
+            return HashCodeHelper.Combine(_range, _value);
         }
 
         /// <summary>

--- a/Core/ALife.Core/Utility/Numerics/CircularBoundedNumber.cs
+++ b/Core/ALife.Core/Utility/Numerics/CircularBoundedNumber.cs
@@ -149,8 +149,7 @@ namespace ALife.Core.Utility.Numerics
         /// </returns>
         public override int GetHashCode()
         {
-            int hashCode = Value.GetHashCode() + _range.GetHashCode();
-            return hashCode;
+            return HashCodeHelper.Combine(_range, _value);
         }
 
         /// <summary>

--- a/Core/ALife.Core/Utility/Numerics/DeltaBoundedNumber.cs
+++ b/Core/ALife.Core/Utility/Numerics/DeltaBoundedNumber.cs
@@ -205,11 +205,9 @@ namespace ALife.Core.Utility.Numerics
         /// <returns>
         /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table.
         /// </returns>
-        //TODO: This hashcode calculation is incorrect and may not be necessary
         public override int GetHashCode()
         {
-            int hashCode = Value.GetHashCode() + DeltaMaximum.GetHashCode();
-            return hashCode;
+            return HashCodeHelper.Combine(_deltaMaximum, _value);
         }
 
         /// <summary>

--- a/Core/ALife.Core/Utility/Numerics/ManualBoundedNumber.cs
+++ b/Core/ALife.Core/Utility/Numerics/ManualBoundedNumber.cs
@@ -190,11 +190,9 @@ namespace ALife.Core.Utility.Numerics
         /// <returns>
         /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table.
         /// </returns>
-        //TODO: This hashcode calculation is incorrect and may not be necessary
         public override int GetHashCode()
         {
-            int hashCode = _range.GetHashCode() + _value.GetHashCode();
-            return hashCode;
+            return HashCodeHelper.Combine(_range, _value);
         }
 
         /// <summary>

--- a/Core/ALife.Core/Utility/Ranges/Range.cs
+++ b/Core/ALife.Core/Utility/Ranges/Range.cs
@@ -162,8 +162,7 @@ namespace ALife.Core.Utility.Ranges
         /// </returns>
         public override int GetHashCode()
         {
-            int hashCode = _minimum.GetHashCode() + _maximum.GetHashCode();
-            return hashCode;
+            return HashCodeHelper.Combine(_minimum, _maximum);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

Adds a way to combine hashcodes ala HashCode.Combine (since we can't directly have that due to .Net Standard 2).

## Changes

- Adds HashCodeHelper class, with an overloaded Combine method allowing combining hashcodes to generate a new hashcode
- Updates structs in the Utility directory to use the new HashCodeHelper.Combine methods to generate hashcodes