### PR TITLE
View Past State Fixed

### DIFF
--- a/Core/ALife.Core/WorldObjects/AgentShadow.cs
+++ b/Core/ALife.Core/WorldObjects/AgentShadow.cs
@@ -1,4 +1,4 @@
-﻿using ALife.Core.Geometry.Shapes;
+using ALife.Core.Geometry.Shapes;
 using ALife.Core.Geometry.Shapes.ChildShapes;
 using ALife.Core.Utility.Colours;
 using ALife.Core.WorldObjects.Agents;
@@ -7,15 +7,12 @@ using System.Collections.Generic;
 
 namespace ALife.Core.WorldObjects
 {
-    public class AgentShadow : IHasShape
+    public class AgentShadow : WorldObjectShadow
     {
         public readonly List<IShape> SenseShapes = new List<IShape>();
 
-        public AgentShadow(Agent self)
+        public AgentShadow(Agent self) : base(self)
         {
-            shape = self.Shape.CloneShape();
-            shape.DebugColour = Colour.Yellow;
-            shape.Orientation = self.Shape.Orientation.Clone();
             foreach(SenseCluster sc in self.Senses)
             {
                 IChildShape cs = sc.Shape as IChildShape;
@@ -24,11 +21,6 @@ namespace ALife.Core.WorldObjects
                 clone.Colour = Colour.White;
                 SenseShapes.Add(clone);
             }
-        }
-        private IShape shape;
-        public IShape Shape
-        {
-            get { return shape; }
         }
     }
 }

--- a/Core/ALife.Core/WorldObjects/Agents/Agent.cs
+++ b/Core/ALife.Core/WorldObjects/Agents/Agent.cs
@@ -31,11 +31,7 @@ namespace ALife.Core.WorldObjects.Agents
             private set;
         }
 
-        public AgentShadow Shadow
-        {
-            get;
-            private set;
-        }
+        public override AgentShadow Shadow => (AgentShadow)_shadow;
 
         /// <summary>
         /// The Parent of the agent.
@@ -101,7 +97,7 @@ namespace ALife.Core.WorldObjects.Agents
 
             Parent = parent;
             LivingAncestor = parent;
-            Shadow = new AgentShadow(this);
+            _shadow = new AgentShadow(this);
             if(AddToWorld)
             {
                 //Release them out into the world
@@ -139,17 +135,20 @@ namespace ALife.Core.WorldObjects.Agents
             Planet.World.RemoveWorldObject(this);
         }
 
-        public override void ExecuteAliveTurn()
+        protected override void CaptureShadow()
         {
-            //Save the previous state of agent, so we can look back on it next turn.
-            if(Planet.World.GenerateShadow)
+            if(Alive)
             {
-                Shadow = new AgentShadow(this);
+                _shadow = new AgentShadow(this);
             }
             else
             {
-                Shadow = null;
+                _shadow = null;
             }
+        }
+
+        public override void ExecuteAliveTurn()
+        {
             JustReproduced = false;
 
             MyBrain.ExecuteTurn();

--- a/Core/ALife.Core/WorldObjects/WorldObject.cs
+++ b/Core/ALife.Core/WorldObjects/WorldObject.cs
@@ -49,6 +49,9 @@ namespace ALife.Core.WorldObjects
         }
         public bool Alive;
 
+        protected WorldObjectShadow _shadow;
+        public virtual WorldObjectShadow Shadow => _shadow;
+
         protected WorldObject(Point centrePoint, IShape shape, string genusLabel, string individualLabel, string collisionLevel, Colour color)
         {
             NumChildren = 0;
@@ -74,6 +77,15 @@ namespace ALife.Core.WorldObjects
         /* METHODS */
         public virtual void ExecuteTurn()
         {
+            if(Planet.World.GenerateShadow)
+            {
+                CaptureShadow();
+            }
+            else
+            {
+                _shadow = null;
+            }
+
             if(Alive)
             {
                 ExecuteAliveTurn();
@@ -82,6 +94,11 @@ namespace ALife.Core.WorldObjects
             {
                 ExecuteDeadTurn();
             }
+        }
+
+        protected virtual void CaptureShadow()
+        {
+            _shadow = new WorldObjectShadow(this);
         }
 
         /// <summary>

--- a/Core/ALife.Core/WorldObjects/WorldObjectShadow.cs
+++ b/Core/ALife.Core/WorldObjects/WorldObjectShadow.cs
@@ -1,0 +1,19 @@
+using ALife.Core.Geometry.Shapes;
+using ALife.Core.Utility.Colours;
+
+namespace ALife.Core.WorldObjects
+{
+    public class WorldObjectShadow : IHasShape
+    {
+        protected IShape shape;
+
+        public WorldObjectShadow(WorldObject self)
+        {
+            shape = self.Shape.CloneShape();
+            shape.DebugColour = Colour.Yellow;
+            shape.Orientation = self.Shape.Orientation.Clone();
+        }
+
+        public IShape Shape => shape;
+    }
+}

--- a/Core/ALife.Rendering/RenderLogic.cs
+++ b/Core/ALife.Rendering/RenderLogic.cs
@@ -166,7 +166,7 @@ namespace ALife.Rendering
                     RenderLogic.DrawAgentShadow(ag.Shadow, uiSettings, auiSettings, renderer);
                     continue;
                 }
-
+                
                 RenderLogic.DrawPastObject(ag.Shadow.Shape, uiSettings, renderer);
             }
         }

--- a/Core/ALife.Rendering/RenderLogic.cs
+++ b/Core/ALife.Rendering/RenderLogic.cs
@@ -150,24 +150,18 @@ namespace ALife.Rendering
                     continue;
                 }
 
-                if(!(wo is Agent))
+                if (compnumber == wo.ExecutionOrder && wo is Agent)
                 {
-                    //TODO: Should ALL objects have shadows??
-                    //TODO: Yes, they should, because some objects (like the falling rock) move. 
-                    //TODO: Currently they don't.
-                    RenderLogic.DrawPastObject(wo.Shape, uiSettings, renderer);
-                    continue;
-                }
-
-                Agent ag = (Agent)wo;
-
-                if(compnumber == wo.ExecutionOrder)
-                {
+                    Agent ag = (Agent)wo;
                     RenderLogic.DrawAgentShadow(ag.Shadow, uiSettings, auiSettings, renderer);
                     continue;
                 }
                 
-                RenderLogic.DrawPastObject(ag.Shadow.Shape, uiSettings, renderer);
+                if (wo.Shadow is not null)
+                {
+                    RenderLogic.DrawPastObject(wo.Shadow.Shape, uiSettings, renderer);
+                }
+                
             }
         }
 

--- a/Core/ALife.Rendering/RenderedSimulationController.cs
+++ b/Core/ALife.Rendering/RenderedSimulationController.cs
@@ -99,9 +99,12 @@ namespace ALife.Rendering
                 {
                     RenderLogic.DrawPastState(ui, aui, renderer, SpecialObject.ExecutionOrder);
                 }
-                foreach(WorldObject wo in Planet.World.CollisionLevels[ui.LayerName].EnumerateItems())
+                else
                 {
-                    RenderLogic.DrawWorldObject(wo, ui, aui, renderer);
+                    foreach(WorldObject wo in Planet.World.CollisionLevels[ui.LayerName].EnumerateItems())
+                    {
+                        RenderLogic.DrawWorldObject(wo, ui, aui, renderer);
+                    }
                 }
             }
             catch(Exception)

--- a/Core/ALife.Rendering/RenderedSimulationController.cs
+++ b/Core/ALife.Rendering/RenderedSimulationController.cs
@@ -95,7 +95,9 @@ namespace ALife.Rendering
                 }
 
                 
-                if(SpecialObject is not null && ViewPast)
+                if(SpecialObject is not null 
+                    && SpecialObject.Shadow is not null
+                    && ViewPast)
                 {
                     RenderLogic.DrawPastState(ui, aui, renderer, SpecialObject.ExecutionOrder);
                 }

--- a/Runners/Avalonia/ALife.Avalonia/Controls/WorldCanvas.cs
+++ b/Runners/Avalonia/ALife.Avalonia/Controls/WorldCanvas.cs
@@ -24,9 +24,6 @@ namespace ALife.Avalonia.Controls;
 
 public class WorldCanvas : Control
 {
-    public static readonly DirectProperty<WorldCanvas, bool> EnabledProperty =
-        AvaloniaProperty.RegisterDirect<WorldCanvas, bool>(nameof(Enabled), x => x.Enabled, (x, v) => x.Enabled = v);
-
     public static readonly DirectProperty<WorldCanvas, string> ScenarioNameProperty =
         AvaloniaProperty.RegisterDirect<WorldCanvas, string>(nameof(ScenarioName), x => x.ScenarioName, (x, v) => x.ScenarioName = v);
 
@@ -49,7 +46,7 @@ public class WorldCanvas : Control
     // Sim thread state — all readable from the background thread without UI-thread access.
     private Thread? _simThread;
     private volatile bool _simThreadRunning;
-    private volatile bool _isRunning;   // mirrors IsEnabled, updated via OnPropertyChanged
+    private volatile bool _isRunning = true;
 
     // volatile double is not legal in C# — store as long bits via Interlocked instead.
     private long TargetSpeedBits = BitConverter.DoubleToInt64Bits((int)SimulationSpeed.Normal);
@@ -59,7 +56,6 @@ public class WorldCanvas : Control
         set => Interlocked.Exchange(ref TargetSpeedBits, BitConverter.DoubleToInt64Bits(value));
     }
 
-    private bool _enabled;
     private AvaloniaRenderer? _renderer;
     private readonly RenderedSimulationController _simulation = new();
     private int _turnCount;
@@ -96,10 +92,10 @@ public class WorldCanvas : Control
 
     // ── Public API ───────────────────────────────────────────────────────────
 
-    public bool Enabled
+    public bool IsSimulationRunning
     {
-        get => _enabled;
-        set => SetAndRaise(EnabledProperty, ref _enabled, value);
+        get => _isRunning;
+        set => _isRunning = value;
     }
 
     public string ScenarioName
@@ -131,6 +127,7 @@ public class WorldCanvas : Control
         _special = agent;
         _specialCounter = 0;
         _simulation.SpecialObject = agent;
+        Planet.World.GenerateShadow = agent is not null;
         InvalidateVisual();
     }
 
@@ -190,36 +187,6 @@ public class WorldCanvas : Control
         }
     }
 
-    // ── Avalonia overrides ───────────────────────────────────────────────────
-
-    // Sync _isRunning (sim-thread-readable) with IsEnabled (UI-thread-only).
-    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
-    {
-        base.OnPropertyChanged(change);
-        if (change.Property == IsEnabledProperty && change.NewValue is bool enabled)
-            _isRunning = enabled;
-    }
-
-    protected override void OnKeyDown(KeyEventArgs e)
-    {
-        base.OnKeyDown(e);
-        if (e.Key == Key.X)
-        {
-            _simulation.ViewPast = true;
-            InvalidateVisual();
-        }
-    }
-
-    protected override void OnKeyUp(KeyEventArgs e)
-    {
-        base.OnKeyUp(e);
-        if (e.Key == Key.X)
-        {
-            _simulation.ViewPast = false;
-            InvalidateVisual();
-        }
-    }
-
     // ── Private ─────────────────────────────────────────────────────────────
 
     // 60 Hz UI-thread callback: initializes on first call, then drives render + VM.
@@ -237,7 +204,6 @@ public class WorldCanvas : Control
             _renderer = new AvaloniaRenderer();
             PointerPressed += OnPointerPressed;
 
-            _isRunning = IsEnabled;
             _simThreadRunning = true;
             _simThread = new Thread(SimLoop) { IsBackground = true, Name = "ALife-Sim" };
             _simThread.Start();
@@ -379,7 +345,7 @@ public class WorldCanvas : Control
         _vm.AgentsActive = agentCount;
         _vm.GenesActive = geneCount.Count;
 
-        if (agentCount == 0 && IsEnabled)
+        if (agentCount == 0 && _isRunning)
         {
             _zeroAgentTicks++;
             if (_zeroAgentTicks >= 5)
@@ -413,5 +379,6 @@ public class WorldCanvas : Control
         if (_vm == null) return;
         _vm.SelectedAgent = _special as Agent;
         _simulation.SpecialObject = _special;
+        Planet.World.GenerateShadow = (_special is not null);
     }
 }

--- a/Runners/Avalonia/ALife.Avalonia/Views/SimulatorView.axaml
+++ b/Runners/Avalonia/ALife.Avalonia/Views/SimulatorView.axaml
@@ -142,8 +142,7 @@
       <controls:WorldCanvas Name="TheWorldCanvas"
                             HorizontalAlignment="Center" VerticalAlignment="Center"
                             ScenarioName="{Binding StartingScenarioName}"
-                            StartingSeed="{Binding StartingSeed}"
-                            Enabled="{Binding IsEnabled}" />
+                            StartingSeed="{Binding StartingSeed}" />
     </paz:ZoomBorder>
 
     <!-- ── Row 2: GridSplitter ── -->

--- a/Runners/Avalonia/ALife.Avalonia/Views/SimulatorView.axaml.cs
+++ b/Runners/Avalonia/ALife.Avalonia/Views/SimulatorView.axaml.cs
@@ -43,6 +43,9 @@ public partial class SimulatorView : UserControl, IDisposable
         ZoomBorder.ZoomChanged += (_, _) => UpdateZoomLabel();
         TheWorldCanvas.AllAgentsDied += (_, _) => SetRunState(false);
 
+        AddHandler(KeyDownEvent, OnViewKeyDown, RoutingStrategies.Tunnel | RoutingStrategies.Bubble);
+        AddHandler(KeyUpEvent, OnViewKeyUp, RoutingStrategies.Tunnel | RoutingStrategies.Bubble);
+
         SetRunState(true);
 
         _perfUpdateTask = Task.Run(() => UpdatePerfLoop(_cts.Token));
@@ -75,7 +78,7 @@ public partial class SimulatorView : UserControl, IDisposable
         Reset_Click(sender, args);
     }
 
-    public void PlayPause_Click(object sender, RoutedEventArgs args) => SetRunState(!TheWorldCanvas.IsEnabled);
+    public void PlayPause_Click(object sender, RoutedEventArgs args) => SetRunState(!TheWorldCanvas.IsSimulationRunning);
 
     public void OneTurn_Click(object sender, RoutedEventArgs args)
     {
@@ -239,7 +242,7 @@ public partial class SimulatorView : UserControl, IDisposable
 
     private void DescendantComboBox_DropDownOpened(object sender, EventArgs e)
     {
-        _wasRunningBeforeDescendantOpen = TheWorldCanvas.IsEnabled;
+        _wasRunningBeforeDescendantOpen = TheWorldCanvas.IsSimulationRunning;
         Vm.FreezeDescendantUpdates = true;
         SetRunState(false);
     }
@@ -266,7 +269,7 @@ public partial class SimulatorView : UserControl, IDisposable
     private void AgentComboBox_DropDownOpened(object sender, EventArgs e)
     {
         if (!ALife.Core.Planet.HasWorld) return;
-        _wasRunningBeforeDescendantOpen = TheWorldCanvas.IsEnabled;
+        _wasRunningBeforeDescendantOpen = TheWorldCanvas.IsSimulationRunning;
         Vm.FreezeDescendantUpdates = true;
         SetRunState(false);
         var agents = ALife.Core.Planet.World.AllActiveObjects
@@ -300,9 +303,27 @@ public partial class SimulatorView : UserControl, IDisposable
         GC.SuppressFinalize(this);
     }
 
+    private void OnViewKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.X && !TheWorldCanvas.Simulation.ViewPast)
+        {
+            TheWorldCanvas.Simulation.ViewPast = true;
+            TheWorldCanvas.InvalidateVisual();
+        }
+    }
+
+    private void OnViewKeyUp(object? sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.X)
+        {
+            TheWorldCanvas.Simulation.ViewPast = false;
+            TheWorldCanvas.InvalidateVisual();
+        }
+    }
+
     private void SetRunState(bool running)
     {
-        TheWorldCanvas.IsEnabled = running;
+        TheWorldCanvas.IsSimulationRunning = running;
         if (Vm != null) Vm.IsEnabled = running;
 
         PlayPauseButton.Content = running ? "⏸ Pause" : "▶ Resume";


### PR DESCRIPTION
View past state never worked in avalonia, and had actually been broken since the winforms days I think. 
It required some weird quirky fixes, but it mostly works now. 
The WorldCanvas is also no longer disabled on Pause. It can still be zoomed, scrolled, selected, etc.